### PR TITLE
Add `offset` option to `getLocaleFromUrl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,16 @@ Accept-Language: zh-CN,zh;q=0.5
 Cookie: locale=zh-TW
 ```
 
-#### ctx.getLocaleFromUrl(), ctx.request.getLocaleFromUrl()
+#### ctx.getLocaleFromUrl(options), ctx.request.getLocaleFromUrl(options)
 
 ```
 http://koajs.com/en
+```
+
+```
+options = { offset: 2 }
+
+http://koajs.com/foo/bar/en
 ```
 
 #### ctx.getLocaleFromTLD(), ctx.request.getLocaleFromTLD()

--- a/index.js
+++ b/index.js
@@ -63,9 +63,9 @@ module.exports = function(app, key) {
 
   // From URL, `http://koajs.com/en`
   Object.defineProperty(request, 'getLocaleFromUrl', {
-    value: function() {
+    value: function(options) {
       var segments = this.path.substring(1).split('/');
-      return segments.shift();
+      return segments[options && options.offset || 0];
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Fangdun Cai <cfddream@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "bluebird": "^3.4.0",
     "koa": "^0.18.1",
     "koa-compose": "*",
     "mocha": "^2.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -136,6 +136,21 @@ describe('koa-locale', function() {
         .expect(/en/)
         .expect(200, done);
     });
+
+    it('should get a locale from URL with given `options.offset`', function(done) {
+      var app = koa();
+
+      locale(app);
+
+      app.use(function*(next) {
+        this.body = this.getLocaleFromUrl({ offset: 2 });
+      });
+
+      request(app.listen())
+        .get('/foo/bar/en')
+        .expect(/en/)
+        .expect(200, done);
+    });
   });
 
   describe('getLocaleFromTLD()', function() {


### PR DESCRIPTION
This PR adds the `offset` option to `getLocaleFromUrl`, which makes:

```js
ctx.getLocaleFromUrl({ offset: 1 });
```

Match **en** for paths like */foo/en/bar*.